### PR TITLE
chore: ファビコンとOGPを追加

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -1,4 +1,4 @@
-import type { DocsThemeConfig } from 'nextra-theme-docs'
+import { useConfig, type DocsThemeConfig } from 'nextra-theme-docs'
 
 const siteTitle = 'PrAha Entrance Book';
 
@@ -21,5 +21,50 @@ export default {
     return {
       titleTemplate: `%s | ${siteTitle}`,
     };
+  },
+  head: () => {
+    const { title } = useConfig();
+    return (
+      <>
+        <meta 
+          property='og:url'
+          content='https://entrance.praha-inc.com/'
+        />
+        <meta
+          property='og:title'
+          content={`${title} | ${siteTitle}`}
+        />
+        <meta
+          property='og:image'
+          content='https://storage.googleapis.com/production-os-assets/assets/3e2414da-29eb-4a09-a665-b35ce4ecb451'
+        />
+        <meta 
+          property='og:type'
+          content='website'
+        />
+        <meta
+          name='description'
+          content='株式会社PrAhaのEntrance Bookです。'
+        />
+        <link
+          rel='icon'
+          type='image/png'
+          href='https://storage.googleapis.com/production-os-assets/assets/20ca8184-a65b-42b5-8571-78324aef53bd'
+        />
+        <link
+          rel='apple-touch-icon'
+          type='image/png'
+          href='https://storage.googleapis.com/production-os-assets/assets/20ca8184-a65b-42b5-8571-78324aef53bd'
+        />
+        <meta
+          property='twitter:card'
+          content='summary_large_image'
+        />
+        <meta
+          property='twitter:image'
+          content='https://storage.googleapis.com/production-os-assets/assets/3e2414da-29eb-4a09-a665-b35ce4ecb451'
+        />
+      </>
+    );
   },
 } satisfies DocsThemeConfig;


### PR DESCRIPTION
[praha-inc.com](praha-inc.com)のホームページで使用されていたOGP画像を流用しました！

- close #56 
- close #57 
　

プレビュー👇です。


<img width="600" alt="スクリーンショット 2024-08-05 15 30 31" src="https://github.com/user-attachments/assets/d675bfaf-6b61-4ed9-aec9-1fc5dab7d045">
<img width="600" alt="スクリーンショット 2024-08-05 15 30 24" src="https://github.com/user-attachments/assets/8be5a71e-03c5-4ba3-a11f-32e4ba150c28">
