### PR TITLE
chore: Vercelサイトの所有権を証明するための記述を追加

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,19 @@
+
+import { Html, Head, Main, NextScript } from 'next/document'
+import { FC } from 'react'
+
+const Document: FC = () => {
+  return (
+    <Html lang="ja">
+      <Head />
+      {/* NOTE: Vercelにホスティングしているサイトの所有権をGoogle Search Consoleに証明するための記述 */}
+      <meta name="google-site-verification" content="5IkFk6t1_lJKoUI7Rofgi6RPwERUS0v6wzKU7eG9RT4" />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}
+
+export default Document;


### PR DESCRIPTION

Google Search Console上で「Vercelのサイトから独自ドメインに引っ越したよ〜」という手続きをしたい
→そのために「このVercelのサイトは私のものです」を証明しないといけない
→それを証明するための記述

という感じです。

Google Tag Manager側でこのタグを書けばいいと思ってたのですが、headタグの中に書かないとダメっぽいので、仕方なく直書きしました。