### PR TITLE
chore: Vercel→Cloudflareにリダイレクトする設定を追加

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,23 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  async redirects() {
+    return [
+      // NOTE: VercelのサイトからCloudflareの独自ドメインにリダイレクトするための設定
+      // TODO: Vercelのサイトを削除したらこの記述も削除する
+      {
+        source: '/:path*',
+        has: [
+          {
+            type: 'host',
+            value: 'praha.vercel.app',
+          },
+        ],
+        destination: 'https://entrance.praha-inc.com/:path*',
+        permanent: true,
+      },
+    ]
+  },
 }
 
 module.exports = withNextra(nextConfig);


### PR DESCRIPTION
Google Search Console上で「Vercel→Cloudflareに引っ越したよ！」を設定する場合、事前にリダイレクトを設定しておかないといけないっぽかったので👇、設定しました！

<img width="1721" alt="スクリーンショット 2024-08-26 12 14 26" src="https://github.com/user-attachments/assets/ab4ac0e3-31f2-4d15-8a5c-a137105e8090">
